### PR TITLE
Update container runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 .pyc
 _build
+tags
+.quay_creds

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,26 @@
-FROM centos:7
-ARG workshop_name=example-workshop
-ENV WORKSHOP_NAME=$workshop_name
-ENV STUDENT_NAME='example student'
-ENV BASTION_HOST='bastion.example.com'
-ENV MASTER_URL='ocp.example.com'
-ENV APP_DOMAIN='apps.example.com'
-RUN yum -y install epel-release; yum -y install python-devel python-setuptools python-pip make; yum -y clean all
-COPY requirements.txt entrypoint.sh workshops/$workshop_name /opt/docs/
-WORKDIR /opt/docs
-RUN pip install --trusted-host pypi.org --trusted-host files.pythonhosted.org --upgrade pip
-RUN pip install --trusted-host pypi.org --trusted-host files.pythonhosted.org -r requirements.txt
-EXPOSE 8080
-CMD ["/opt/docs/entrypoint.sh"]
+FROM centos:latest
 LABEL maintainer="creynold@redhat.com"
+
+ARG workshop_name=example-workshop
+ENV WORKSHOP_NAME=$workshop_name \
+    STUDENT_NAME='example student' \
+    BASTION_HOST='bastion.example.com' \
+    MASTER_URL='ocp.example.com' \
+    APP_DOMAIN='apps.example.com'
+
+COPY requirements.txt entrypoint.sh workshops/$workshop_name /opt/docs/
 RUN chmod -R u+x /opt/docs && \
     chgrp -R 0 /opt/docs && \
-    chmod -R g=u /opt/docs
+    chmod -R g=u /opt/docs && \
+    yum -y install epel-release && \
+    yum -y install python3-devel python3-setuptools python3-pip make && \
+    yum -y update && \
+    yum -y clean all --enablerepo='*'
+
+WORKDIR /opt/docs
+RUN pip3 install --trusted-host pypi.org --trusted-host files.pythonhosted.org --upgrade pip setuptools && \
+    pip3 install --trusted-host pypi.org --trusted-host files.pythonhosted.org -r requirements.txt
+
+EXPOSE 8080
+CMD ["/opt/docs/entrypoint.sh"]
 USER 10001

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -1,30 +1,30 @@
 #! /usr/bin/env bash
 # Helper script to build container images for each workshop
-# if using podman, be sure to install the podman-docker package
-# also, if using podman, up th
 
 WORKSHOP_NAME=$1
-if [[ ${#3} -eq 0 ]];then
-  QUAY_PROJECT=creynold
-else
-  QUAY_PROJECT=$3
+LOCATION=${2:local}
+QUAY_PROJECT=${3:-rhcreynold}
+
+cd $(dirname $(realpath $0))/..
+if [ -f .quay_creds ]; then
+  LOCATION=quay
+  . .quay_creds
 fi
 
-
-case $2 in
+case $LOCATION in
   local)
-    docker build --build-arg workshop_name=$WORKSHOP_NAME \
-    -t quay.io/$QUAY_PROJECT/operator-workshop-lab-guide-$WORKSHOP_NAME \
-    .
+    podman build --build-arg workshop_name=$WORKSHOP_NAME \
+      -t quay.io/$QUAY_PROJECT/operator-workshop-lab-guide-$WORKSHOP_NAME .
   ;;
   quay)
     # designed to be used by travis-ci, where the docker_* variables are defined
-    echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin quay.io
-    docker build --build-arg workshop_name=$WORKSHOP_NAME \
-    -t quay.io/$QUAY_PROJECT/operator-workshop-lab-guide-$WORKSHOP_NAME .
-    docker push quay.io/$QUAY_PROJECT/operator-workshop-lab-guide-$WORKSHOP_NAME
+    echo "$DOCKER_PASSWORD" | podman login -u "$DOCKER_USERNAME" --password-stdin quay.io
+
+    podman build --build-arg workshop_name=$WORKSHOP_NAME \
+      -t quay.io/$QUAY_PROJECT/operator-workshop-lab-guide-$WORKSHOP_NAME .
+    podman push quay.io/$QUAY_PROJECT/operator-workshop-lab-guide-$WORKSHOP_NAME
   ;;
   *)
-    echo "usage: ./hack/build.sh <WORKSHOP_NAME> <LOCATION>"
+    echo "usage: ./hack/build.sh WORKSHOP_NAME [local|quay] [QUAY_PROJECT]"
   ;;
 esac

--- a/hack/prep-ansible-for-devops.sh
+++ b/hack/prep-ansible-for-devops.sh
@@ -1,15 +1,12 @@
 #! /usr/bin/env bash
 
 ENV_FILE=$1
+STUDENT_NAME=${2:-student1}
 
-echo "Preparing environment variables for $WORKSHOP_NAME lab guide"
+echo "Preparing environment variables for ansible-for-devops lab guide"
 
-STUDENT_NAME=$(grep student /etc/passwd | awk -F':' '{ print $1 }')
-if [[ ${#STUDENT_NAME} -eq 0 ]];then
-  STUDENT_NAME=student1
-fi
 INVENTORY_FILE=/home/$STUDENT_NAME/devops-workshop/lab_inventory/hosts
-if [ -f $INVENTORY_FILE ];then
+if [ -f $INVENTORY_FILE ]; then
   CONTROL_PRIVATE_IP=$(grep 'ansible ansible_host' $INVENTORY_FILE | awk -F'=' '{ print $2 }')
   STUDENT_PASS=$(grep ansible_ssh_pass $INVENTORY_FILE | awk -F= '{ print $2 }')
   CONTROL_PUBLIC_IP=$(curl http://169.254.169.254/latest/meta-data/public-ipv4)

--- a/hack/prep-better-together.sh
+++ b/hack/prep-better-together.sh
@@ -1,13 +1,9 @@
 #! /usr/bin/env bash
 
 ENV_FILE=$1
-
+STUDENT_NAME=${2:-student1}
 echo "Preparing environment variables for $WORKSHOP_NAME lab guide"
 
-STUDENT_NAME=$(grep student /etc/passwd | awk -F':' '{ print $1 }')
-if [[ ${#STUDENT_NAME} -eq 0 ]];then
-  STUDENT_NAME=student1
-fi
 STUDENT_PASS=redhat01
 OPENSHIFT_VER=3.11
 CONTROL_PUBLIC_IP=192.168.10.1

--- a/hack/run.sh
+++ b/hack/run.sh
@@ -1,69 +1,96 @@
 #! /usr/bin/env bash
 # Helper function to run the newly built containers in various locations
-# It assumes docker at this point.
+
+cd $(dirname $(realpath $0))/..
 
 WORKSHOP_NAME=$1
 RUN_TYPE=$2
-QUAY_USER=creynold
-TMP_FILE=/tmp/lab_guide_id_$WORKSHOP_NAME
-ENV_FILE=/tmp/env.list
-CONTAINER_IMAGE=quay.io/$QUAY_USER/operator-workshop-lab-guide-$WORKSHOP_NAME
-if [[ ${#3} -eq 0 ]];then
-  PORT=8888
-else
-  PORT=$3
-fi
+QUAY_PROJECT=${3:-rhcreynold}
+PORT=${4:-8888}
+ENV_FILE=${5:-/tmp/env.list}
+CONTAINER_IMAGE=quay.io/$QUAY_PROJECT/operator-workshop-lab-guide-$WORKSHOP_NAME
+# If STUDENT_NAME is unset, check /etc/passwd for a student, otherwise default
+#   to student1
+STUDENT_NAME=$(_PASSWD_STUDENT=$(awk -F: '/student/{ print $1 }' /etc/passwd);
+               echo ${STUDENT_NAME:-${_PASSWD_STUDENT:-student1}})
 
-# Create the docker run env.list file
-echo "creating the environment variables file at $ENV_FILE"
+# Create the podman run env.list file
+echo "Creating the environment variables file at $ENV_FILE"
+echo "WORKSHOP_NAME=$WORKSHOP_NAME" > $ENV_FILE
 
-echo "WORKSHOP_NAME="$WORKSHOP_NAME > $ENV_FILE
+setup_local() {
+  stop_local
+
+  existing_container=$(podman ps -a -f name=$WORKSHOP_NAME --format='{{ $.ID }}')
+  if [ "$existing_container" ]; then
+    echo Removing existing $WORKSHOP_NAME container ID $existing_container
+    podman rm -f $existing_container
+  fi
+
+  echo Defining podman container from $CONTAINER_IMAGE
+  podman create --env-file $ENV_FILE --name $WORKSHOP_NAME -p $PORT:8080 $CONTAINER_IMAGE
+
+  echo Dropping systemd unit file
+  cat << EOF > $HOME/.config/systemd/user/$WORKSHOP_NAME.service
+[Unit]
+Description=$WORKSHOP_NAME Lab Guide container
+Wants=network.target multi-user.target
+After=network.target
+
+[Service]
+Restart=always
+ExecStart=/usr/bin/podman start -a $WORKSHOP_NAME
+ExecStop=/usr/bin/podman stop -t 2 $WORKSHOP_NAME
+
+[Install]
+WantedBy=local.target
+EOF
+  systemctl --user daemon-reload
+
+  echo Enabling systemd unit
+  systemctl --user enable $WORKSHOP_NAME.service
+}
 
 stop_local() {
-  if [ -f $TMP_FILE ]; then
-    LAB_CONTAINER=$(cat $TMP_FILE | cut -c1-12)
-    echo "Stopping $WORKSHOP_NAME container ID $LAB_CONTAINER"
-    docker rm -f $LAB_CONTAINER > /dev/null
-    if [ $? -eq 0 ]; then
-      echo "Lab Guide for $WORKSHOP_NAME stopped"
-      rm -f $TMP_FILE
-    fi
+  if systemctl --user | grep -qF $WORKSHOP_NAME; then
+    echo Stopping $WORKSHOP_NAME container
+    systemctl --user stop $WORKSHOP_NAME.service
   else
-    echo "No lab guides are currently running"
+    echo No lab guide for $WORKSHOP_NAME installed
   fi
 }
 
 start_local() {
-  echo "Preparing new lab guide for $WORKSHOP_NAME"
-  if [[ $RUN_TYPE = 'start' ]]; then
-    docker pull $CONTAINER_IMAGE
-  fi
+  stop_local
+
+  echo Ensuring setup complete
+  systemctl --user | grep -qF $WORKSHOP_NAME || setup_local
+
   ENV_PREP_SCRIPT=prep-$WORKSHOP_NAME.sh
-  if [ -f ./hack/$ENV_PREP_SCRIPT ]; then
-    ./hack/$ENV_PREP_SCRIPT $ENV_FILE
+  if [ -f hack/$ENV_PREP_SCRIPT ]; then
+    hack/$ENV_PREP_SCRIPT $ENV_FILE $STUDENT_NAME
   fi
-  docker run -d --env-file /tmp/env.list --name lab_guide_$WORKSHOP_NAME -p $PORT:8080 $CONTAINER_IMAGE &> $TMP_FILE
-  if [ $? -eq 0 ]; then
-    LAB_CONTAINER=$(cat $TMP_FILE | cut -c1-12)
-    echo "$WORKSHOP_NAME is running as container ID $LAB_CONTAINER and is avaiable at http://localhost:$PORT"
-  fi
-  rm -f $ENV_FILE
+
+  podman pull $CONTAINER_IMAGE
+
+  echo Starting systemd container for $WORKSHOP_NAME
+  systemctl --user start $WORKSHOP_NAME
 }
 
 case $2 in
+  setup)
+    setup_local
+  ;;
   start)
-    stop_local
     start_local
   ;;
   local)
-    stop_local
     start_local
   ;;
   stop)
     stop_local
   ;;
   *)
-    echo "Usage: ./run.sh <WORKSHOP_NAME> <TARGET>"
-    echo "Valid targets: 'local', 'start', 'stop'"
+    echo "Usage: ./run.sh WORKSHOP_NAME (setup|local|start|stop) [QUAY_PROJECT_NAME] [PORT] [ENV_FILE_PATH]" >&2
   ;;
 esac

--- a/hack/run.sh
+++ b/hack/run.sh
@@ -31,6 +31,7 @@ setup_local() {
   podman create --env-file $ENV_FILE --name $WORKSHOP_NAME -p $PORT:8080 $CONTAINER_IMAGE
 
   echo Dropping systemd unit file
+  mkdir -p $HOME/.config/systemd/user
   cat << EOF > $HOME/.config/systemd/user/$WORKSHOP_NAME.service
 [Unit]
 Description=$WORKSHOP_NAME Lab Guide container

--- a/workshops/ansible-for-devops/conf.py
+++ b/workshops/ansible-for-devops/conf.py
@@ -27,7 +27,8 @@ extensions = [
 
 # -- Project information -----------------------------------------------------
 
-project_clean = unicode(os.environ['WORKSHOP_NAME'].title().replace('_', ' ').replace('-',' '))
+project_clean = os.environ['WORKSHOP_NAME'].title()
+project_clean = project_clean.replace('_', ' ').replace('-', ' ')
 
 # -- Project information -----------------------------------------------------
 


### PR DESCRIPTION
Convert build and run tasks to use `podman` instead of `docker`, provide some more modularity in how the scripts run, enable local auto-pushing via a .gitignore'd dot-file, but still maintain command line compatibility with existing Travis systems.

Note that no workshop content has been updated to reflect `podman` instead of `docker` yet. Separate PR incoming at some point later (hopefully this week?).