### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,6 @@ jobs:
     - stage: deploy
       script: bash hack/build.sh ${WORKSHOP_NAME} quay ${QUAY_REPOSITORY:-creynold}
       env: WORKSHOP_NAME=better-together
+after_failure:
+  - systemctl --user status ${WORKSHOP_NAME}
+  - journalctl --user -u ${WORKSHOP_NAME}

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,12 @@ stages:
   - name: deploy
     if: branch = master
 before_script:
-  # https://github.com/containers/libpod/blob/master/install.md#ubuntu
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq -y software-properties-common uidmap curl
-  - sudo add-apt-repository -y ppa:projectatomic/ppa
+  # https://podman.io/getting-started/installation#ubuntu
+  - . /etc/os-release
+  - echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /' | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+  - curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
   - sudo apt-get update -qq
   - sudo apt-get -qq -y install podman
-  - sudo mkdir -p /etc/containers
-  - echo -e "[registries.search]\nregistries = ['docker.io', 'quay.io']" | sudo tee /etc/containers/registries.conf
 script: hack/run.sh ${WORKSHOP_NAME} local --project=${QUAY_REPOSITORY:-creynold} --test
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,29 @@
-language: python
-python:
-- '2.7'
+language: minimal
 env:
   - WORKSHOP_NAME=example-workshop
   - WORKSHOP_NAME=ansible-for-devops
   - WORKSHOP_NAME=better-together
-services:
-- docker
-install:
-- pip install -r requirements.txt
+before_install:
+  # https://github.com/containers/libpod/blob/master/install.md#ubuntu
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq -y software-properties-common uidmap
+  - sudo add-apt-repository -y ppa:projectatomic/ppa
+  - sudo apt-get update -qq
+  - sudo apt-get -qq -y install podman
+
+  # Show version and info.
+  - podman --version
+  - podman version
+  - podman info --debug
+  - apt-cache show podman
+  - dpkg-query -L podman
+
+  # Hack podman's configuration files.
+  # /etc/containers/registries.conf does not exist.
+  # https://clouding.io/kb/en/how-to-install-and-use-podman-on-ubuntu-18-04/
+  - ls -1 /etc/containers/registries.conf || true
+  - sudo mkdir -p /etc/containers
+  - echo -e "[registries.search]\nregistries = ['docker.io', 'quay.io']" | sudo tee /etc/containers/registries.conf
 script:
 - bash hack/run.sh ${WORKSHOP_NAME} local
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,12 @@ before_install:
   - ls -1 /etc/containers/registries.conf || true
   - sudo mkdir -p /etc/containers
   - echo -e "[registries.search]\nregistries = ['docker.io', 'quay.io']" | sudo tee /etc/containers/registries.conf
-script:
-- bash hack/run.sh ${WORKSHOP_NAME} local ${QUAY_REPOSITORY:-creynold}
-deploy:
-  provider: script
-  script: bash hack/build.sh ${WORKSHOP_NAME} quay ${QUAY_REPOSITORY:-creynold}
-  on:
-    branch: master
+jobs:
+  include:
+    - stage: test
+      script: hack/run.sh ${WORKSHOP_NAME} local ${QUAY_REPOSITORY:-creynold}
+    - script: curl localhost:8888 || exit 1
+    - stage: deploy
+      script: bash hack/build.sh ${WORKSHOP_NAME} quay ${QUAY_REPOSITORY:-creynold}
+      on:
+        branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,28 @@
+dist: bionic
 language: minimal
 env:
   - WORKSHOP_NAME=example-workshop
   - WORKSHOP_NAME=ansible-for-devops
   - WORKSHOP_NAME=better-together
-before_install:
+stages:
+  - test
+  - name: deploy
+    if: branch = master
+before_script:
   # https://github.com/containers/libpod/blob/master/install.md#ubuntu
   - sudo apt-get update -qq
-  - sudo apt-get install -qq -y software-properties-common uidmap
+  - sudo apt-get install -qq -y software-properties-common uidmap curl
   - sudo add-apt-repository -y ppa:projectatomic/ppa
   - sudo apt-get update -qq
   - sudo apt-get -qq -y install podman
-
-  # Show version and info.
-  - podman --version
-  - podman version
-  - podman info --debug
-  - apt-cache show podman
-  - dpkg-query -L podman
-
-  # Hack podman's configuration files.
-  # /etc/containers/registries.conf does not exist.
-  # https://clouding.io/kb/en/how-to-install-and-use-podman-on-ubuntu-18-04/
-  - ls -1 /etc/containers/registries.conf || true
   - sudo mkdir -p /etc/containers
   - echo -e "[registries.search]\nregistries = ['docker.io', 'quay.io']" | sudo tee /etc/containers/registries.conf
+script: hack/run.sh ${WORKSHOP_NAME} local ${QUAY_REPOSITORY:-creynold} && sleep 10 && curl localhost:8888 || exit 1
 jobs:
   include:
-    - stage: test
-      script: hack/run.sh ${WORKSHOP_NAME} local ${QUAY_REPOSITORY:-creynold}
-    - script: curl localhost:8888 || exit 1
     - stage: deploy
       script: bash hack/build.sh ${WORKSHOP_NAME} quay ${QUAY_REPOSITORY:-creynold}
-      on:
-        branch: master
+      env: WORKSHOP_NAME=ansible-for-devops
+    - stage: deploy
+      script: bash hack/build.sh ${WORKSHOP_NAME} quay ${QUAY_REPOSITORY:-creynold}
+      env: WORKSHOP_NAME=better-together

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_script:
   - echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
   - curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
   - sudo apt-get update -qq
-  - sudo apt-get -qq -y install podman
+  - sudo apt-get -qq -y install podman slirp4netns
 script: hack/run.sh ${WORKSHOP_NAME} local --project=${QUAY_REPOSITORY:-creynold} --test
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ before_install:
   - sudo mkdir -p /etc/containers
   - echo -e "[registries.search]\nregistries = ['docker.io', 'quay.io']" | sudo tee /etc/containers/registries.conf
 script:
-- bash hack/run.sh ${WORKSHOP_NAME} local
+- bash hack/run.sh ${WORKSHOP_NAME} local ${QUAY_REPOSITORY:-creynold}
 deploy:
   provider: script
-  script: bash hack/build.sh ${WORKSHOP_NAME} quay
+  script: bash hack/build.sh ${WORKSHOP_NAME} quay ${QUAY_REPOSITORY:-creynold}
   on:
     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ stages:
 before_script:
   # https://podman.io/getting-started/installation#ubuntu
   - . /etc/os-release
-  - echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /' | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+  - echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
   - curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
   - sudo apt-get update -qq
   - sudo apt-get -qq -y install podman

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
   - sudo apt-get -qq -y install podman
   - sudo mkdir -p /etc/containers
   - echo -e "[registries.search]\nregistries = ['docker.io', 'quay.io']" | sudo tee /etc/containers/registries.conf
-script: hack/run.sh ${WORKSHOP_NAME} local ${QUAY_REPOSITORY:-creynold} && sleep 10 && curl localhost:8888 || exit 1
+script: hack/run.sh ${WORKSHOP_NAME} local --project=${QUAY_REPOSITORY:-creynold} --test
 jobs:
   include:
     - stage: deploy
@@ -26,6 +26,3 @@ jobs:
     - stage: deploy
       script: bash hack/build.sh ${WORKSHOP_NAME} quay ${QUAY_REPOSITORY:-creynold}
       env: WORKSHOP_NAME=better-together
-after_failure:
-  - systemctl --user status ${WORKSHOP_NAME}
-  - journalctl --user -u ${WORKSHOP_NAME}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ ENV WORKSHOP_NAME=$workshop_name \
     MASTER_URL='ocp.example.com' \
     APP_DOMAIN='apps.example.com'
 
-COPY requirements.txt entrypoint.sh workshops/$workshop_name /opt/docs/
-RUN chmod -R u+x /opt/docs && \
+RUN mkdir -p /opt/docs && \
+    chmod -R u+x /opt/docs && \
     chgrp -R 0 /opt/docs && \
     chmod -R g=u /opt/docs && \
     yum -y install epel-release && \
@@ -17,6 +17,7 @@ RUN chmod -R u+x /opt/docs && \
     yum -y update && \
     yum -y clean all --enablerepo='*'
 
+COPY requirements.txt entrypoint.sh workshops/$workshop_name /opt/docs/
 WORKDIR /opt/docs
 RUN pip3 install --trusted-host pypi.org --trusted-host files.pythonhosted.org --upgrade pip setuptools && \
     pip3 install --trusted-host pypi.org --trusted-host files.pythonhosted.org -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ RUN mkdir -p /opt/docs && \
 
 COPY requirements.txt entrypoint.sh workshops/$workshop_name /opt/docs/
 WORKDIR /opt/docs
-RUN pip3 install --trusted-host pypi.org --trusted-host files.pythonhosted.org --upgrade pip setuptools && \
-    pip3 install --trusted-host pypi.org --trusted-host files.pythonhosted.org -r requirements.txt
+RUN pip3 install --trusted-host pypi.org --trusted-host files.pythonhosted.org --no-cache-dir --upgrade pip setuptools && \
+    pip3 install --trusted-host pypi.org --trusted-host files.pythonhosted.org --no-cache-dir -r requirements.txt
 
 EXPOSE 8080
 CMD ["/opt/docs/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,4 +3,4 @@
 
 make dirhtml
 cp -r _build/dirhtml/_static .
-cd _build/dirhtml && python -m SimpleHTTPServer 8080
+cd _build/dirhtml && python3 -m http.server 8080

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -3,7 +3,7 @@
 
 WORKSHOP_NAME=$1
 LOCATION=${2:local}
-QUAY_PROJECT=${3:-rhcreynold}
+QUAY_PROJECT=${3:-creynold}
 
 cd $(dirname $(realpath $0))/..
 if [ -f .quay_creds ]; then

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -17,12 +17,15 @@ case $LOCATION in
       -t quay.io/$QUAY_PROJECT/operator-workshop-lab-guide-$WORKSHOP_NAME .
   ;;
   quay)
+    echo Logging in to quay.io
     # designed to be used by travis-ci, where the docker_* variables are defined
-    echo "$DOCKER_PASSWORD" | podman login -u "$DOCKER_USERNAME" --password-stdin quay.io
+    echo "$DOCKER_PASSWORD" | podman login -u "$DOCKER_USERNAME" --password-stdin quay.io || exit 1
 
+    echo Building image
     podman build --build-arg workshop_name=$WORKSHOP_NAME \
-      -t quay.io/$QUAY_PROJECT/operator-workshop-lab-guide-$WORKSHOP_NAME .
-    podman push quay.io/$QUAY_PROJECT/operator-workshop-lab-guide-$WORKSHOP_NAME
+      -t quay.io/$QUAY_PROJECT/operator-workshop-lab-guide-$WORKSHOP_NAME . || exit 2
+    echo Pushing image
+    podman push quay.io/$QUAY_PROJECT/operator-workshop-lab-guide-$WORKSHOP_NAME || exit 3
   ;;
   *)
     echo "usage: ./hack/build.sh WORKSHOP_NAME [local|quay] [QUAY_PROJECT]"

--- a/hack/run.sh
+++ b/hack/run.sh
@@ -180,7 +180,7 @@ case $RUN_TYPE in
   ;;
 esac
 
-if [ -n "$do_tests" -a -n "$testable"]; then
+if [ -n "$do_tests" -a -n "$testable" ]; then
   count=0
   step=5
   max_failures=12

--- a/hack/run.sh
+++ b/hack/run.sh
@@ -112,11 +112,11 @@ container_installed() {
 start_local() {
   stop_local
 
-  echo Ensuring setup complete
-  container_installed || setup_local
-
   echo Running dedicated local build
   hack/build.sh $WORKSHOP_NAME local $QUAY_PROJECT || exit 1
+
+  echo Ensuring setup complete
+  container_installed || setup_local
 
   echo Starting systemd container for $WORKSHOP_NAME
   systemctl --user start $WORKSHOP_NAME
@@ -125,11 +125,11 @@ start_local() {
 start() {
   stop_local
 
-  echo Ensuring setup complete
-  container_installed || setup_local
-
   echo Pulling image $CONTAINER_IMAGE
   podman pull $CONTAINER_IMAGE || exit 1
+
+  echo Ensuring setup complete
+  container_installed || setup_local
 
   echo Starting systemd container for $WORKSHOP_NAME
   systemctl --user start $WORKSHOP_NAME

--- a/hack/run.sh
+++ b/hack/run.sh
@@ -175,7 +175,7 @@ if [ "$do_tests" ]; then
   count=0
   step=5
   max_failures=6
-  while ! curl localhost:$PORT; do
+  while ! curl 127.0.0.1:$PORT; do
     (( count++ ))
     echo "Failed attempt $count of $max_failures.... retrying in $step" >&2
     sleep $step

--- a/hack/run.sh
+++ b/hack/run.sh
@@ -177,12 +177,12 @@ if [ "$do_tests" ]; then
   max_failures=6
   while ! curl 127.0.0.1:$PORT; do
     (( count++ ))
-    echo "Failed attempt $count of $max_failures.... retrying in $step" >&2
-    sleep $step
     if [ $count -gt $max_failures ]; then
       systemctl --user status $WORKSHOP_NAME
       journalctl --user -u $WORKSHOP_NAME
       exit 13
     fi
+    echo "Failed attempt $count of $max_failures.... retrying in $step" >&2
+    sleep $step
   done
 fi

--- a/hack/run.sh
+++ b/hack/run.sh
@@ -200,4 +200,5 @@ if [ "$do_tests" ]; then
     sleep $step
   done
   curl localhost:8888 |& grep -F '<title>'
+  stop_local
 fi

--- a/hack/run.sh
+++ b/hack/run.sh
@@ -153,10 +153,6 @@ remove_local() {
     systemctl --user daemon-reload
     systemctl --user reset-failed
   fi
-  image_ids=$(podman images --filter label=$CONTAINER_IMAGE --format='{{ $.ID }}')
-  if [ "$image_ids" ]; then
-    podman rmi --force $(podman images --filter label=$CONTAINER_IMAGE --format='{{ $.ID }}')
-  fi
 }
 
 testable=''

--- a/hack/run.sh
+++ b/hack/run.sh
@@ -184,10 +184,12 @@ esac
 if [ "$do_tests" ]; then
   count=0
   step=5
-  max_failures=6
+  max_failures=12
   while ! curl 127.0.0.1:$PORT &>/dev/null; do
     (( count++ ))
     if [ $count -ge $max_failures ]; then
+      echo "Failed attempt $count of $max_failures.... dumping logs" >&2
+      echo
       echo systemctl --user status $WORKSHOP_NAME:
       systemctl --user status $WORKSHOP_NAME | sed 's/^/  /'
       echo journalctl --user -u $WORKSHOP_NAME:

--- a/hack/run.sh
+++ b/hack/run.sh
@@ -199,5 +199,5 @@ if [ "$do_tests" ]; then
     echo "Failed attempt $count of $max_failures.... retrying in $step" >&2
     sleep $step
   done
+  curl localhost:8888 |& grep -F '<title>'
 fi
-curl localhost:8888 |& grep -F '<title>'

--- a/hack/run.sh
+++ b/hack/run.sh
@@ -177,7 +177,7 @@ if [ "$do_tests" ]; then
   max_failures=6
   while ! curl 127.0.0.1:$PORT; do
     (( count++ ))
-    if [ $count -gt $max_failures ]; then
+    if [ $count -ge $max_failures ]; then
       systemctl --user status $WORKSHOP_NAME
       journalctl --user -u $WORKSHOP_NAME
       exit 13

--- a/hack/run.sh
+++ b/hack/run.sh
@@ -175,11 +175,13 @@ if [ "$do_tests" ]; then
   count=0
   step=5
   max_failures=6
-  while ! curl 127.0.0.1:$PORT; do
+  while ! curl 127.0.0.1:$PORT &>/dev/null; do
     (( count++ ))
     if [ $count -ge $max_failures ]; then
-      systemctl --user status $WORKSHOP_NAME
-      journalctl --user -u $WORKSHOP_NAME
+      echo systemctl --user status $WORKSHOP_NAME:
+      systemctl --user status $WORKSHOP_NAME | sed 's/^/  /'
+      echo journalctl --user -u $WORKSHOP_NAME:
+      journalctl --user -u $WORKSHOP_NAME | sed 's/^/  /'
       exit 13
     fi
     echo "Failed attempt $count of $max_failures.... retrying in $step" >&2

--- a/hack/run.sh
+++ b/hack/run.sh
@@ -175,7 +175,7 @@ if [ "$do_tests" ]; then
   count=0
   step=5
   max_failures=6
-  while ! curl localhost:8888; do
+  while ! curl localhost:$PORT; do
     (( count++ ))
     echo "Failed attempt $count of $max_failures.... retrying in $step" >&2
     sleep $step

--- a/hack/run.sh
+++ b/hack/run.sh
@@ -159,15 +159,18 @@ remove_local() {
   fi
 }
 
+testable=''
 case $RUN_TYPE in
   setup)
     setup_local
   ;;
   start)
     start
+    testable=true
   ;;
   local)
     start_local
+    testable=true
   ;;
   stop)
     stop_local
@@ -181,7 +184,7 @@ case $RUN_TYPE in
   ;;
 esac
 
-if [ "$do_tests" ]; then
+if [ -n "$do_tests" -a -n "$testable"]; then
   count=0
   step=5
   max_failures=12

--- a/hack/run.sh
+++ b/hack/run.sh
@@ -1,31 +1,76 @@
 #! /usr/bin/env bash
 # Helper function to run the newly built containers in various locations
 
+print_usage() {
+  echo "Usage: ./run.sh WORKSHOP_NAME (setup|local|start|stop|remove) [(-p |--port=)PORT]" >&2
+  echo "       [--project=QUAY_PROJECT_NAME] [(-e |--env-file=)ENV_FILE_PATH] [--test]" >&2
+}
+
 cd $(dirname $(realpath $0))/..
 
 WORKSHOP_NAME=$1
-RUN_TYPE=$2
-QUAY_PROJECT=${3:-creynold}
-PORT=${4:-8888}
-ENV_FILE=${5:-/tmp/env.list}
-CONTAINER_IMAGE=quay.io/$QUAY_PROJECT/operator-workshop-lab-guide-$WORKSHOP_NAME
+shift
+RUN_TYPE=$1
+shift
+
+# defaults
+QUAY_PROJECT=creynold
+PORT=8888
+ENV_FILE=/tmp/env.list
+do_tests=''
+
 # If STUDENT_NAME is unset, check /etc/passwd for a student, otherwise default
 #   to student1
-STUDENT_NAME=$(_PASSWD_STUDENT=$(awk -F: '/student/{ print $1 }' /etc/passwd);
-               echo ${STUDENT_NAME:-${_PASSWD_STUDENT:-student1}})
+export STUDENT_NAME=$(_PASSWD_STUDENT=$(awk -F: '/student/{ print $1 }' /etc/passwd);
+                      echo ${STUDENT_NAME:-${_PASSWD_STUDENT:-student1}})
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --project=*)
+      QUAY_PROJECT=$(echo "$1" | cut -d= -f2-)
+      ;;
+    -p|--port=*)
+      if [ "$1" = '-p' ]; then
+        shift
+        PORT="$1"
+      else
+        PORT=$(echo "$1" | cut -d= -f2-)
+      fi
+      ;;
+    -e|--env-file=*)
+      if [ "$1" = '-e' ]; then
+        shift
+        ENV_FILE="$1"
+      else
+        ENV_FILE=$(echo "$1" | cut -d= -f2-)
+      fi
+      ;;
+    --test)
+      do_tests=true
+      ;;
+    *)
+      print_usage
+      exit 1
+      ;;
+  esac; shift
+done
+
+# Relies on options
+CONTAINER_IMAGE=quay.io/$QUAY_PROJECT/operator-workshop-lab-guide-$WORKSHOP_NAME
 
 # Create the podman run env.list file
-echo "Creating the environment variables file at $ENV_FILE"
-echo "WORKSHOP_NAME=$WORKSHOP_NAME" > $ENV_FILE
-
 setup_local() {
   stop_local
 
-  existing_container=$(podman ps -a -f name=$WORKSHOP_NAME --format='{{ $.ID }}')
-  if [ "$existing_container" ]; then
-    echo Removing existing $WORKSHOP_NAME container ID $existing_container
-    podman rm -f $existing_container
+  echo "Creating the environment variables file at $ENV_FILE"
+  echo "WORKSHOP_NAME=$WORKSHOP_NAME" > $ENV_FILE
+  ENV_PREP_SCRIPT=prep-$WORKSHOP_NAME.sh
+  if [ -f hack/$ENV_PREP_SCRIPT ]; then
+    echo Running prep script
+    hack/$ENV_PREP_SCRIPT $ENV_FILE $STUDENT_NAME
   fi
+
+  remove_container
 
   echo Defining podman container from $CONTAINER_IMAGE
   podman create --env-file $ENV_FILE --name $WORKSHOP_NAME -p $PORT:8080 $CONTAINER_IMAGE
@@ -65,12 +110,6 @@ start_local() {
   echo Ensuring setup complete
   systemctl --user | grep -qF $WORKSHOP_NAME || setup_local
 
-  ENV_PREP_SCRIPT=prep-$WORKSHOP_NAME.sh
-  if [ -f hack/$ENV_PREP_SCRIPT ]; then
-    echo Running prep script
-    hack/$ENV_PREP_SCRIPT $ENV_FILE $STUDENT_NAME
-  fi
-
   echo Running dedicated local build
   hack/build.sh $WORKSHOP_NAME local $QUAY_PROJECT || exit 1
 
@@ -84,11 +123,6 @@ start() {
   echo Ensuring setup complete
   systemctl --user | grep -qF $WORKSHOP_NAME || setup_local
 
-  ENV_PREP_SCRIPT=prep-$WORKSHOP_NAME.sh
-  if [ -f hack/$ENV_PREP_SCRIPT ]; then
-    hack/$ENV_PREP_SCRIPT $ENV_FILE $STUDENT_NAME
-  fi
-
   echo Pulling image $CONTAINER_IMAGE
   podman pull $CONTAINER_IMAGE || exit 1
 
@@ -96,7 +130,26 @@ start() {
   systemctl --user start $WORKSHOP_NAME
 }
 
-case $2 in
+remove_container() {
+  existing_container=$(podman ps -a -f name=$WORKSHOP_NAME --format='{{ $.ID }}')
+  if [ "$existing_container" ]; then
+    echo Removing existing $WORKSHOP_NAME container ID $existing_container
+    podman rm -f $existing_container
+  fi
+}
+
+remove_local() {
+  rm -f $ENV_FILE
+  remove_container
+  systemctl --user stop $WORKSHOP_NAME.service
+  systemctl --user disable $WORKSHOP_NAME.service
+  rm -f $HOME/.config/systemd/user/$WORKSHOP_NAME.service
+  systemctl --user daemon-reload
+  systemctl --user reset-failed
+  podman rmi --force $(podman images --filter label=$CONTAINER_IMAGE --format='{{ $.ID }}')
+}
+
+case $RUN_TYPE in
   setup)
     setup_local
   ;;
@@ -109,7 +162,27 @@ case $2 in
   stop)
     stop_local
   ;;
+  remove)
+    remove_local
+  ;;
   *)
-    echo "Usage: ./run.sh WORKSHOP_NAME (setup|local|start|stop) [QUAY_PROJECT_NAME] [PORT] [ENV_FILE_PATH]" >&2
+    print_usage
+    exit 1
   ;;
 esac
+
+if [ "$do_tests" ]; then
+  count=0
+  step=5
+  max_failures=6
+  while ! curl localhost:8888; do
+    (( count++ ))
+    echo "Failed attempt $count of $max_failures.... retrying in $step" >&2
+    sleep $step
+    if [ $count -gt $max_failures ]; then
+      systemctl --user status $WORKSHOP_NAME
+      journalctl --user -u $WORKSHOP_NAME
+      exit 13
+    fi
+  done
+fi

--- a/hack/run.sh
+++ b/hack/run.sh
@@ -188,3 +188,4 @@ if [ "$do_tests" ]; then
     sleep $step
   done
 fi
+curl localhost:8888 |& grep -F '<title>'

--- a/hack/run.sh
+++ b/hack/run.sh
@@ -44,7 +44,7 @@ ExecStart=/usr/bin/podman start -a $WORKSHOP_NAME
 ExecStop=/usr/bin/podman stop -t 2 $WORKSHOP_NAME
 
 [Install]
-WantedBy=local.target
+WantedBy=multi-user.target
 EOF
   systemctl --user daemon-reload
 

--- a/hack/run.sh
+++ b/hack/run.sh
@@ -5,7 +5,7 @@ cd $(dirname $(realpath $0))/..
 
 WORKSHOP_NAME=$1
 RUN_TYPE=$2
-QUAY_PROJECT=${3:-rhcreynold}
+QUAY_PROJECT=${3:-creynold}
 PORT=${4:-8888}
 ENV_FILE=${5:-/tmp/env.list}
 CONTAINER_IMAGE=quay.io/$QUAY_PROJECT/operator-workshop-lab-guide-$WORKSHOP_NAME

--- a/workshops/ansible-for-devops/conf.py
+++ b/workshops/ansible-for-devops/conf.py
@@ -236,7 +236,7 @@ epub_exclude_files = ['search.html']
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
 
 # -- Options for todo extension ----------------------------------------------
 

--- a/workshops/example-workshop/conf.py
+++ b/workshops/example-workshop/conf.py
@@ -24,7 +24,7 @@ extensions = [
 
 import os
 
-project_clean = unicode(os.environ['WORKSHOP_NAME'].title().replace('_', ' ').replace('-',' '))
+project_clean = os.environ['WORKSHOP_NAME'].title().replace('_', ' ').replace('-',' ')
 
 project = project_clean
 copyright = u'2019, Red Hat, Inc.'


### PR DESCRIPTION
Recommend squash merge! Full list of fixes:

- Converted Travis build to minimal bionic w/ podman
- Made Travis pipeline into multi-stage so deploys on master only occur if tests pass, but tests can run on any branch appropriately with locally-built containers
- Reordered Dockerfile to use smarter layer caching during dev
- Reduced size of built images slightly by not caching PyPI packages
- Converted entrypoint.sh to definitely-python-3
- Corrected default Quay project name to not be your GitHub account name, oops
- Tweaked verbosity throughout run script to prevent excessive nits and enable better fault detection in travis
- Converted most run.sh args from positional to optional w/ flags, except the most basic ones
- Improved setup behavior, and made systemd unit definitely start on boot
- Removed some more code redundancy
- Added option to fully uninstall a lab guide
- Integrated a `curl localhost` type self-test option via flag to at least make sure the guides come up
- Corrected some older Sphinx syntax
- Updated example-workshop conf.py to python3